### PR TITLE
Integrate more powershell features

### DIFF
--- a/clipper.ps1
+++ b/clipper.ps1
@@ -18,7 +18,9 @@ param (
 	[switch]$useLocalDeps,
 	[string]$customFormat = "NONE", # For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter, use only if you know what you're doing.
 	[switch]$isIkari, # For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter, use only if you know what you're doing.
+	[ValidateRange(0, 30)]
 	[int]$paddingInt = 5,
+	[ValidateRange(0, [int]::MaxValue)]
 	[int]$parallelChunkSize = 5
 )
 
@@ -56,19 +58,6 @@ if ($useAltCodecs -and $siteType -eq "other") {
 if (!$doNotStitch -and $miniclipFileExt -ne "mp4") {
 	Write-Warning "-doNotStitch is false, ignoring -miniclipFileExt."
 	$miniclipFileExt = "mp4"
-}
-# Hmm, could have sworn there used to be some extra warnings here... oh well.
-if ($paddingInt -gt 30) {
-	$paddingInt = 30
-}
-if ($paddingInt -lt 0) {
-	$paddingInt = 0
-}
-if ($paddingInt -gt 60) {
-	$paddingInt = 60
-}
-if ($parallelChunkSize -lt 0) {
-	$parallelChunkSize = 0
 }
 
 # Global Variables

--- a/clipper.ps1
+++ b/clipper.ps1
@@ -41,10 +41,7 @@ $ffmpegExts = @(
 )
 
 # Input Checks
-if ($ffmpegExts -cnotcontains $outputFileExt.toLower()) {
-	Throw "ERROR: Invalid output file extension"
-}
-if ($ffmpegExts -cnotcontains $miniclipFileExt.toLower()) {
+if ($ffmpegExts -notcontains $outputFileExt -or $ffmpegExts -notcontains $miniclipFileExt) {
 	Throw "ERROR: Invalid output file extension"
 }
 if ($videoLink.Host -like "*youtube*" -or $videoLink.Host -like "*youtu.be*") {

--- a/clipper.ps1
+++ b/clipper.ps1
@@ -1,25 +1,60 @@
-# HoloClipper Revision 11 Version 1
-# I regret writing this in PowerShell
+<#
+.SYNOPSIS
+	Tool for automating the clipping process
+.DESCRIPTION
+	HoloClipper Revision 11 Version 1
+	I regret writing this in PowerShell
 
-# Written and Tested by Sheer Curiosity
+	VCDL is a PowerShell-based clipping script for downloading specific portions of videos from YouTube and other video
+	sites. It runs natively on Windows, and on Linux / macOS with PowerShell installed.
+
+	Written and Tested by Sheer Curiosity
+.LINK
+	https://github.com/HoloRes/vcdl/blob/main/readme.md
+#>
 param (
-	[string]$outputTitle = "output", # Defines the output filename, without extension    Options: Any Title You Want
-	[string]$siteType, # Deprecated, now determined automatically                        Options: Youtube, Other
+	# Output filename, without extension. Any valid string works, but keep in mind not all characters are valid
+	# as part of a filname. On windows these characters are forbidden: < > : " / \ | ? *
+	[string]$outputTitle = "output",
+	# Deprecated, now determined automatically
+	[string]$siteType,
+	# Link to download video from. May be any link that yt-dlp is able to recognize.
 	[Parameter(Mandatory=$true, Position=0)]
-	[uri]$videoLink, # Defines input link                                                Options: YouTube Links and Direct Video File Links
-	[string]$dlDir = ".", # Defines the download directory for the final file            Options: Any Directory On Your PC
+	[uri]$videoLink,
+	# Output directory for the final file. Should be a directory on your PC.
+	[Alias("outputDirectory")]
+	[string]$dlDir = ".",
+	# Timestamps to be clipped. Multiple subclips are separated by commas without spaces
+	# Example: [hh:mm:ss-hh:mm:ss]
+	# Example: [hh:mm:ss-hh:mm:ss],[hh:mm:ss-hh:mm:ss]
 	[Parameter(Mandatory=$true, Position=1)]
-	[string]$timestamps, # Defines the timestamps to be clipped                          Options: Timestamps In This Format (Add Comma & No Space For Multiple Subclips): [xx:xx:xx-xx:xx:xx],[xx:xx:xx-xx:xx:xx]
-	[string]$outputFileExt = "mp4", # Defines the output file extension                  Options: Any Video Extensions Supported By FFMPEG
+	[string]$timestamps,
+	# Output file extension. May be any extension type that FFMPEG supports.
+	[string]$outputFileExt = "mp4",
+	# Output file extension. May be any extension type that FFMPEG supports.
 	[string]$miniclipFileExt = "mp4",
+	# Allows the script to download videos above 1080p using YouTube's VP9 and AV1 codecs.
+	# If set, this parameter will add extra re-encoding.
 	[switch]$useAltCodecs,
+	# Rescales the stitched clip to 1080p. Intended to be used with videos below 1080p.
 	[switch]$rescaleVideo,
+	# If more than one pair of timestamps are passed, this will save each timestamp pair as its own video.
+	# Works in conjunction with -miniclipFileExt.
 	[switch]$doNotStitch,
+	# Deprecated, now determined automatically
 	[switch]$useLocalDeps,
-	[string]$customFormat = "NONE", # For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter, use only if you know what you're doing.
-	[switch]$isIkari, # For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter, use only if you know what you're doing.
+	# For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter,
+	# use only if you know what you're doing.
+	[string]$customFormat = "NONE",
+	# For Hololive Resort's internal project manager Ikari. No documentation will be provided for this parameter,
+	# use only if you know what you're doing.
+	[switch]$isIkari,
+	# Specifies the amount of time, in seconds, to add to the start and end of each miniclip. Between 0 and 30.
+	# This extra time is referred to as the "time buffer" in the online docs.
 	[ValidateRange(0, 30)]
 	[int]$paddingInt = 5,
+	# Specifies the maximum number of ffmpeg processes to run in parallel. Mainly used to help lower the memory
+	# footprint of the script. Setting this to a value over 10 is not advised, do so at your own risk.
 	[ValidateRange(0, [int]::MaxValue)]
 	[int]$parallelChunkSize = 5
 )

--- a/clipper.ps1
+++ b/clipper.ps1
@@ -62,15 +62,19 @@ if (!$doNotStitch -and $miniclipFileExt -ne "mp4") {
 
 # Global Variables
 $tempdir = "./temp"
-$ffmpegExecutable = "ffmpeg.exe"
-$ytdlExecutable = "yt-dlp.exe"
 if (!(Test-Path -Path $tempdir)) {
 	mkdir $tempdir
 }
-if ($useLocalDeps) {
-	$ffmpegExecutable = "./ffmpeg.exe"
-	$ytdlExecutable = "./yt-dlp.exe"
+
+$oldPATH = $env:PATH
+$env:PATH += ";."
+$ffmpegExecutable = Get-Command -Type Application "ffmpeg.exe" -ErrorAction SilentlyContinue
+$ytdlExecutable = Get-Command -Type Application "yt-dlp.exe" -ErrorAction SilentlyContinue
+$env:PATH = $oldPATH
+if (!$ffmpegExecutable -or !$ytdlExecutable) {
+	Throw "Missing needed executables. Please make sure ffmpeg and yt-dlp are on your PATH, or in the current folder."
 }
+
 $finalStartTimestamps = [System.Collections.ArrayList]@()
 $finalRuntimeTimestamps = [System.Collections.ArrayList]@()
 $ffmpegProcesses = [System.Collections.ArrayList]@()

--- a/clipper.ps1
+++ b/clipper.ps1
@@ -5,9 +5,11 @@
 param (
 	[string]$outputTitle = "output", # Defines the output filename, without extension    Options: Any Title You Want
 	[string]$siteType = $null, # Defines the type of video being clipped                 Options: Youtube, Other
-	[string]$videoLink = $null, # Defines input link                                     Options: YouTube Links and Direct Video File Links
+	[Parameter(Mandatory=$true, Position=0)]
+	[string]$videoLink, # Defines input link                                             Options: YouTube Links and Direct Video File Links
 	[string]$dlDir = ".", # Defines the download directory for the final file            Options: Any Directory On Your PC
-	[string]$timestamps = $null, # Defines the timestamps to be clipped                  Options: Timestamps In This Format (Add Comma & No Space For Multiple Subclips): [xx:xx:xx-xx:xx:xx],[xx:xx:xx-xx:xx:xx]
+	[Parameter(Mandatory=$true, Position=1)]
+	[string]$timestamps, # Defines the timestamps to be clipped                          Options: Timestamps In This Format (Add Comma & No Space For Multiple Subclips): [xx:xx:xx-xx:xx:xx],[xx:xx:xx-xx:xx:xx]
 	[string]$outputFileExt = "mp4", # Defines the output file extension                  Options: Any Video Extensions Supported By FFMPEG
 	[string]$miniclipFileExt = "mp4",
 	[switch]$useAltCodecs,
@@ -37,7 +39,7 @@ $ffmpegExts = @(
 )
 
 # Input Checks
-if (!$siteType -or !$videoLink -or !$timestamps) {
+if (!$siteType) {
 	Throw "ERROR: Missing Parameters"
 }
 if ($siteType.ToLower() -ne "youtube" -and $siteType.ToLower() -ne "other") {


### PR DESCRIPTION
A lot of changes in here, but all pretty simple. I have more complicated changes in mind (dynamically generating ffmpeg commands into a splat array instead of a giant if-tree for example) but tried to do minimal changes here. In general this can be summarized as "using powershell features more fully"

- switch parameters instead of string-based "booleans". These are either present or not, and set to $true or $false automatically.
- Mandatory parameters checked at runtime instead of validated internally
- Range validation checked at runtime instead of validated internally
- Stop using `.ToLower()` everywhere since powershell checks are case-insensitive by default, and the script doesn't care either
- use comment-based help so users don't have to reference github documentation
- manipulate path and use get-command to determine where ffmpeg and yt-dlp are
- validate url via typing at runtime, then use that to determine if it's a youtube video instead of asking the user.